### PR TITLE
Force apiKey to be defined

### DIFF
--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -11,6 +11,9 @@ var mailgunHashType = 'sha256';
 var mailgunSignatureEncoding = 'hex';
 
 var Mailgun = function (options) {
+  if(!options.apiKey){
+    throw new Error('apiKey value must be defined!'); 
+  }
   this.username = 'api';
   this.apiKey = options.apiKey;
   this.domain = options.domain;


### PR DESCRIPTION
Last time when i've debug my code for any bugs or mistakes, i've noticed after 2 hours that I passed apikey instead of apiKey value. Would be great to fail first if no apiKey is defined! 