### PR TITLE
Fix Sending MIME message example

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ var mail = mailcomposer({
   from: 'you@samples.mailgun.org',
   to: 'mm@samples.mailgun.org',
   subject: 'Test email subject',
-  body: 'Test email text',
+  text: 'Test email text',
   html: '<b> Test email text </b>'
 });
 


### PR DESCRIPTION
For sending the text version of the email with mailcomposer you have to use the field "text" not "body".