### PR TITLE
Improve tests and promises

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -94,7 +94,11 @@ Builder.prototype.buildAction = function (action) {
     }
 
     this.client = this.base;
-    return this.client.request(action.method, requestPath, data, fn);
+    if (fn) {
+      return this.client.request(action.method, requestPath, data, fn);
+    } else {
+      return this.client.request(action.method, requestPath, data);
+    }
   }
 
   constructor.prototype[getName(actionName)] = function (data, fn) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,6 +1,6 @@
 var inflection = require('inflection');
 var pathProxy = require('path-proxy');
-var Q = require('q');
+var promisifyCall = require('promisify-call');
 
 var noop = function () {
 };
@@ -31,9 +31,7 @@ Builder.prototype.buildAction = function (action) {
   var path = action.href.replace(/\.json/gi, '').replace(/\.mime/gi, '');
   var constructor = pathProxy.pathProxy(this.baseObj, path);
 
-  constructor.prototype[getName(actionName)] = function (data, fn) {
-    var deferred = Q.defer();
-
+  function impl (data, fn) {
     var requestPath = action.href;
     var pathParams = action.href.match(/{[^}]+}/g) || [];
 
@@ -42,13 +40,11 @@ Builder.prototype.buildAction = function (action) {
       data = undefined;
     }
 
-    if (!fn) fn = noop;
-
     var err;
 
     if (this.params.length !== pathParams.length) {
       err = new Error('Invalid number of params in path (expected ' + pathParams.length + ', got ' + this.params.length + ').');
-      return rejectError(err, deferred, fn);
+      return fn(err);
     }
 
     this.params.forEach(function (param) {
@@ -72,7 +68,7 @@ Builder.prototype.buildAction = function (action) {
     }
 
     if (err) {
-      return rejectError(err, deferred, fn);
+      return fn(err);
     }
 
     // check payload property types
@@ -94,20 +90,21 @@ Builder.prototype.buildAction = function (action) {
     }
 
     if (err) {
-      return rejectError(err, deferred, fn);
+      return fn(err);
     }
 
     this.client = this.base;
     return this.client.request(action.method, requestPath, data, fn);
-  };
-}
-;
+  }
 
-function rejectError(err, deferred, fn) {
-  deferred.reject(err);
-  fn(err);
-  return deferred.promise;
-}
+  constructor.prototype[getName(actionName)] = function (data, fn) {
+    if (fn) {
+      return promisifyCall(this, impl, data, fn);
+    } else {
+      return promisifyCall(this, impl, data);
+    }
+  };
+};
 
 function getName(name) {
   name = name.toLowerCase();
@@ -121,7 +118,3 @@ exports.build = function (baseObj, resources) {
   var b = new Builder(baseObj, resources);
   b.build();
 };
-
-
-
-

--- a/lib/build.js
+++ b/lib/build.js
@@ -94,19 +94,11 @@ Builder.prototype.buildAction = function (action) {
     }
 
     this.client = this.base;
-    if (fn) {
-      return this.client.request(action.method, requestPath, data, fn);
-    } else {
-      return this.client.request(action.method, requestPath, data);
-    }
+    return this.client.request(action.method, requestPath, data, fn);
   }
 
   constructor.prototype[getName(actionName)] = function (data, fn) {
-    if (fn) {
-      return promisifyCall(this, impl, data, fn);
-    } else {
-      return promisifyCall(this, impl, data);
-    }
+    return promisifyCall(this, impl, data, fn);
   };
 };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,12 +2,12 @@ var https = require('https');
 var http = require('http');
 var proxy = require('proxy-agent');
 var qs = require('querystring');
-var q = require('q');
 var fs = require('fs');
 var Readable = require('stream').Readable;
 var FormData = require('form-data');
 var Attachment = require('./attachment');
 var retry = require('async').retry;
+var promisifyCall = require('promisify-call');
 
 var debug = require('debug')('mailgun-js');
 
@@ -29,17 +29,8 @@ function Request(options) {
   this.retry = options.retry || 1;
 }
 
-Request.prototype.request = function (method, resource, data, fn) {
-  this.deferred = q.defer();
-
+Request.prototype._request = function (method, resource, data, fn) {
   var self = this;
-
-  if (typeof data === 'function' && !fn) {
-    fn = data;
-    data = {};
-  }
-
-  if (!fn) fn = noop;
 
   var path = ''.concat(this.endpoint, resource);
 
@@ -88,29 +79,33 @@ Request.prototype.request = function (method, resource, data, fn) {
     timeout: this.timeout
   };
 
-  function finalCb(error, body) {
-    if (error) {
-      self.deferred.reject(error);
-    }
-    else {
-      self.deferred.resolve(body);
-    }
-
-    return fn(error, body);
-  }
-
   if (this.retry > 1) {
     retry(this.retry, function (retryCb) {
       self.callback = retryCb;
       self.performRequest(opts);
-    }, finalCb);
+    }, fn);
   }
   else {
-    this.callback = finalCb;
+    this.callback = fn;
     this.performRequest(opts);
   }
+}
 
-  return this.deferred.promise;
+Request.prototype.request = function (method, resource, data, fn) {
+  if (typeof data === 'function' && !fn) {
+    fn = data;
+    data = {};
+  }
+
+  if (!data) {
+    data = {}
+  }
+
+  if(fn) {
+    return promisifyCall(this, this._request, method, resource, data, fn);
+  } else {
+    return promisifyCall(this, this._request, method, resource, data);
+  }
 };
 
 function getDataValue(key, input) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -101,11 +101,7 @@ Request.prototype.request = function (method, resource, data, fn) {
     data = {}
   }
 
-  if(fn) {
-    return promisifyCall(this, this._request, method, resource, data, fn);
-  } else {
-    return promisifyCall(this, this._request, method, resource, data);
-  }
+  return promisifyCall(this, this._request, method, resource, data, fn);
 };
 
 function getDataValue(key, input) {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "inflection": "~1.10.0",
     "is-stream": "^1.1.0",
     "path-proxy": "~1.0.0",
+    "promisify-call": "^1.0.0",
     "proxy-agent": "~2.0.0",
-    "q": "~1.4.0",
     "tsscmp": "~1.0.0"
   },
   "author": {
@@ -47,5 +47,8 @@
     "docs:build": "npm run docs:api && npm run docs:prepare && npm run docs:clean && gitbook build",
     "docs:watch": "npm run docs:api && npm run docs:prepare && gitbook serve",
     "docs:publish": "npm run docs:build && cd _book && git init && git commit --allow-empty -m 'Update docs' && git checkout -b gh-pages && git add . && git commit -am 'Update docs' && git push https://github.com/bojand/mailgun-js.git gh-pages --force"
+  },
+  "directories": {
+    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "http://github.com/bojand/mailgun-js/issues"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">=6.9"
   },
   "main": "./lib/mailgun.js",
   "dependencies": {
@@ -26,7 +26,7 @@
     "inflection": "~1.10.0",
     "is-stream": "^1.1.0",
     "path-proxy": "~1.0.0",
-    "promisify-call": "^1.0.0",
+    "promisify-call": "^2.0.2",
     "proxy-agent": "~2.0.0",
     "tsscmp": "~1.0.0"
   },

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -1,24 +1,24 @@
 {
   "message": {
-    "to": "mailgunjstest+send@gmail.com",
+    "to": "mailgunjs+test1@gmail.com",
     "from": "mailgunjstest+recv1@gmail.com",
     "subject": "Test email subject",
     "text": "Test email text"
   },
   "message_recipient_vars": {
     "to": [
-      "mailgunjstest+recv1@gmail.com",
-      "mailgunjstest+recv2@gmail.com"
+      "mailgunjs+test1@gmail.com",
+      "mailgunjs+test2@gmail.com"
     ],
     "from": "mailgunjstest+send@gmail.com",
     "subject": "Hey, %recipient.first%",
     "text": "Test email text. Your ID: %recipient.id%",
     "recipient-variables": {
-      "mailgunjstest+recv1@gmail.com": {
+      "mailgunjs+test1@gmail.com": {
         "first": "Bob",
         "id": 1
       },
-      "mailgunjstest+recv2@gmail.com": {
+      "mailgunjs+test2@gmail.com": {
         "first": "Alice",
         "id": 2
       }


### PR DESCRIPTION
* Fix tests by using authorized emails
* Improve promise support by using promisify-call. We either use callback or return a promise. No more rejected promise errors when using callback.