### PR TITLE
Changed parameter 'subscribed' to 'upsert' for endpoint /lists/{address}/members.json

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -508,7 +508,7 @@ module.exports = {
               "type": "boolean"
             }
           },
-          "required": ["members", "upsert"]
+          "required": ["members"]
         },
         {
           "description": "Updates a mailing list member with given properties.",

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -504,11 +504,11 @@ module.exports = {
             "members": {
               "type": "array"
             },
-            "subscribed": {
+            "upsert": {
               "type": "boolean"
             }
           },
-          "required": ["members", "subscribed"]
+          "required": ["members", "upsert"]
         },
         {
           "description": "Updates a mailing list member with given properties.",

--- a/test/mailgun.test.js
+++ b/test/mailgun.test.js
@@ -916,8 +916,9 @@ module.exports = {
     ];
 
     mailgun.lists(fixture.mailingList.address).members().add({members: members}, function (err, body) {
-      assert.ok(err);
-      assert(/Missing parameter 'upsert'/.test(err.message));
+      assert.ifError(err);
+      assert.ok(body.list);
+      assert.ok(body.list.members_count >= 0);
       done();
     });
   },

--- a/test/mailgun.test.js
+++ b/test/mailgun.test.js
@@ -902,7 +902,7 @@ module.exports = {
     });
   },
 
-  'test lists().members().add() without subscribed': function (done) {
+  'test lists().members().add() without upsert': function (done) {
     var members = [
       {
         address: 'Alice <alice@example.com>',
@@ -917,7 +917,7 @@ module.exports = {
 
     mailgun.lists(fixture.mailingList.address).members().add({members: members}, function (err, body) {
       assert.ok(err);
-      assert(/Missing parameter 'subscribed'/.test(err.message));
+      assert(/Missing parameter 'upsert'/.test(err.message));
       done();
     });
   },
@@ -937,7 +937,7 @@ module.exports = {
 
     mailgun.lists(fixture.mailingList.address).members().add({
       members: members,
-      subscribed: true
+      upsert: true
     }, function (err, body) {
       assert.ifError(err);
       assert.ok(body.list);


### PR DESCRIPTION
As documented in the [API docs for mailing lists](https://documentation.mailgun.com/api-mailinglists.html#mailing-lists) the endpoint `/lists/{address}/members.json` takes a parameter `upsert` and not `subscribed`. The `upsert` parameter should also be optional.

This pull request simply simply renames the `subscribed` parameter to `upsert` and removes it from the list of required parameters for the `/lists/{address}/members.json` endpoint.