### PR TITLE
Added list and get operations for tags

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -624,6 +624,18 @@ module.exports = {
       "description": "Deletes all counters for particular tag and the tag itself. See http://documentation.mailgun.com/api-stats.html",
       "links": [
         {
+          "description": "List all tags.",
+          "href": "/tags",
+          "method": "GET",
+          "title": "list"
+        },
+        {
+          "description": "Gets a specific tag.",
+          "href": "/tags/{tag}",
+          "method": "GET",
+          "title": "info"
+        },
+        {
           "description": "Deletes all counters for particular tag and the tag itself.",
           "href": "/tags/{tag}",
           "method": "DELETE",


### PR DESCRIPTION
This adds both a ```list``` and ```info``` operation for tags. Not sure why there was only a delete operation.