### PR TITLE
Unref timeout

### DIFF
--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -136,7 +136,7 @@ Mailgun.prototype.validateWebhook = function (timestamp, token, signature) {
 
   this.mailgunTokens[token] = true;
 
-  cosnt tokenTimeout = setTimeout(function () {
+  const tokenTimeout = setTimeout(function () {
     delete self.mailgunTokens[token];
   }, mailgunExpirey + (5 * 1000));
   tokenTimeout.unref();

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -136,10 +136,11 @@ Mailgun.prototype.validateWebhook = function (timestamp, token, signature) {
 
   this.mailgunTokens[token] = true;
 
-  setTimeout(function () {
+  cosnt tokenTimeout = setTimeout(function () {
     delete self.mailgunTokens[token];
   }, mailgunExpirey + (5 * 1000));
-
+  tokenTimeout.unref();
+  
   return tsscmp(
     signature
     , crypto.createHmac(mailgunHashType, self.apiKey)


### PR DESCRIPTION
Call unref on settimeout for tokens 

- Unref the setTimeout call on flushing the tokens so that node processes do not have to wait for the timeout callback to finish (mocha wasn't exiting after tests had finished running).