### PR TITLE
Fix #190: Error callback called twice

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -310,7 +310,13 @@ class Request {
     const method = options.method
 
     if (this.form && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
+      let alreadyHandled = false
       this.form.submit(options, (err, res) => {
+        if (alreadyHandled) {
+          return
+        }
+        alreadyHandled = true
+        
         if (err) {
           return this.callback(err)
         }


### PR DESCRIPTION
Fix issue #190, in which the problem is detailed.

A more elegant way to solve the problem is to use the [once](https://www.npmjs.com/package/once) package, but it adds a dependency.

Then the PR would look like:

```js
   this.form.submit(options, once((err, res) => {
      // ...
   }))
```