### PR TITLE
Support /tags/<tag>/stats

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -316,7 +316,7 @@ class Request {
           return
         }
         alreadyHandled = true
-        
+
         if (err) {
           return this.callback(err)
         }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -629,6 +629,48 @@ module.exports = {
         'title': 'info'
       },
       {
+        'description': 'Returns statistics for a given tag.',
+        'href': '/tags/{tag}/stats',
+        'method': 'GET',
+        'title': 'info',
+        'properties': {
+          'event': {
+            'type': 'array'
+          },
+          'start': {
+            'type': 'string'
+          },
+          'end': {
+            'type': 'string'
+          },
+          'resolution': {
+            'type': 'string'
+          },
+          'duration': {
+            'type': 'string'
+          }
+        },
+        'required': ['event']
+      },
+      {
+        'description': 'Returns a list of countries of origin for a given domain for different event types.',
+        'href': '/tags/{tag}/stats/aggregates/countries',
+        'method': 'GET',
+        'title': 'list'
+      },
+      {
+        'description': 'Returns a list of email providers for a given domain for different event types.',
+        'href': '/tags/{tag}/stats/aggregates/providers',
+        'method': 'GET',
+        'title': 'list'
+      },
+      {
+        'description': 'Returns a list of devices for a given domain that have triggered event types.',
+        'href': '/tags/{tag}/stats/aggregates/devices',
+        'method': 'GET',
+        'title': 'list'
+      },
+      {
         'description': 'Deletes all counters for particular tag and the tag itself.',
         'href': '/tags/{tag}',
         'method': 'DELETE',

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -20,9 +20,46 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().info()', (done) => {
-    mailgun.tags('tag1').info((err, body) => {
+    mailgun.tags('tag2').info((err, body) => {
       assert.ifError(err)
       assert.ok(body)
+      done()
+    })
+  })
+
+  it('test mailgun.tags().stats().info()', (done) => {
+    mailgun.tags('tag2').stats().info({
+      event: ['accepted', 'delivered', 'opened', 'clicked']
+    }, (err, body) => {
+      assert.ifError(err)
+      assert.ok(body)
+      done()
+    })
+  })
+
+  it('test mailgun.tags().aggregates().countries().list()', (done) => {
+    mailgun.tags('tag2').stats().aggregates().countries().list((err, body) => {
+      assert.ifError(err)
+      assert.ok(body)
+      assert.ok(body.countries)
+      done()
+    })
+  })
+
+  it('test mailgun.tags().aggregates().providers().list()', (done) => {
+    mailgun.tags('tag2').stats().aggregates().providers().list((err, body) => {
+      assert.ifError(err)
+      assert.ok(body)
+      assert.ok(body.providers)
+      done()
+    })
+  })
+
+  it('test mailgun.tags().aggregates().devices().list()', (done) => {
+    mailgun.tags('tag2').stats().aggregates().devices().list((err, body) => {
+      assert.ifError(err)
+      assert.ok(body)
+      assert.ok(body.devices)
       done()
     })
   })

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -20,7 +20,7 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().info()', (done) => {
-    mailgun.tags('tag2').info((err, body) => {
+    mailgun.tags('tag1').info((err, body) => {
       assert.ifError(err)
       assert.ok(body)
       done()
@@ -28,7 +28,7 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().stats().info()', (done) => {
-    mailgun.tags('tag2').stats().info({
+    mailgun.tags('tag1').stats().info({
       event: ['accepted', 'delivered', 'opened', 'clicked']
     }, (err, body) => {
       assert.ifError(err)
@@ -38,7 +38,7 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().aggregates().countries().list()', (done) => {
-    mailgun.tags('tag2').stats().aggregates().countries().list((err, body) => {
+    mailgun.tags('tag1').stats().aggregates().countries().list((err, body) => {
       assert.ifError(err)
       assert.ok(body)
       assert.ok(body.countries)
@@ -47,7 +47,7 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().aggregates().providers().list()', (done) => {
-    mailgun.tags('tag2').stats().aggregates().providers().list((err, body) => {
+    mailgun.tags('tag1').stats().aggregates().providers().list((err, body) => {
       assert.ifError(err)
       assert.ok(body)
       assert.ok(body.providers)
@@ -56,7 +56,7 @@ describe('Tags', () => {
   })
 
   it('test mailgun.tags().aggregates().devices().list()', (done) => {
-    mailgun.tags('tag2').stats().aggregates().devices().list((err, body) => {
+    mailgun.tags('tag1').stats().aggregates().devices().list((err, body) => {
       assert.ifError(err)
       assert.ok(body)
       assert.ok(body.devices)


### PR DESCRIPTION
Mailgun sent out a letter and mention their old campaign will be retired on April 9, 2018. Seem we need to use [Tags](http://blog.mailgun.com/tags-explained-gaining-useful-insights-from-email-segmentation/) to replace to get analytics data. So I add the /tags/<tag>/stats & aggregates schemas support. [[api]](https://documentation.mailgun.com/en/latest/api-tags.html#tags)

```
mailgun.tags().stats().info()
mailgun.tags().aggregates().countries().list()
mailgun.tags().aggregates().providers().list()
mailgun.tags().aggregates().devices().list()
```