### PR TITLE
Support async library retry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ list.members('bob@gmail.com').delete(function (err, data) {
 * `port` - the mailgun port (default: '443')
 * `endpoint` - the mailgun host (default: '/v3')
 * `retry` - the number of **total attempts** to do when performing requests. Default is `1`.
-That is, we will try an operation only once with no retries on error.
+That is, we will try an operation only once with no retries on error. You can also use a config 
+object compatible with the `async` library for more control as to how the retries take place.
+See docs [here](https://caolan.github.io/async/docs.html#retry) 
 
 
 #### Attachments

--- a/lib/request.js
+++ b/lib/request.js
@@ -119,7 +119,7 @@ class Request {
       opts.agent = proxy(this.proxy, true)
     }
 
-    if (this.retry > 1) {
+    if (typeof this.retry === 'object' || this.retry > 1) {
       retry(this.retry, (retryCb) => {
         this.callback = retryCb
         this.performRequest(opts)

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -449,5 +449,48 @@ describe('Messages', () => {
         done()
       })
     })
+
+    it('messages().send() should work with retry option as an object', (done) => {
+      const mg = new mailgun.Mailgun({
+        'apiKey': auth.api_key,
+        'domain': auth.domain,
+        'retry': {
+          'times': 3,
+          'interval': 100
+        }
+      })
+
+      const msg = clone(fixture.message)
+
+      mg.messages().send(msg, (err, body) => {
+        assert.ifError(err)
+        assert.ok(body.id)
+        assert.ok(body.message)
+        assert(/Queued. Thank you./.test(body.message))
+        done()
+      })
+    })
+
+    it('messages().send() should retry when request fails with a delay of 100 ms between attempts', (done) => {
+      process.env.DEBUG_MAILGUN_FORCE_RETRY = true
+      const mg = new mailgun.Mailgun({
+        'apiKey': auth.api_key,
+        'domain': auth.domain,
+        'retry': {
+          'times': 3,
+          'interval': 100
+        }
+      })
+
+      const msg = clone(fixture.message)
+
+      mg.messages().send(msg, (err, body) => {
+        assert.ifError(err)
+        assert.ok(body.id)
+        assert.ok(body.message)
+        assert(/Queued. Thank you./.test(body.message))
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
Wanting to add support to use async's retry options. Gives a user more control on backoff intervals and error filtering https://caolan.github.io/async/docs.html#retry

Updated README and added some simple tests