### PR TITLE
Remove smtp password requirement

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -75,14 +75,11 @@ module.exports = {
           'name': {
             'type': 'string'
           },
-          'smtp_password': {
-            'type': 'string'
-          },
           'wildcard': {
             'type': 'boolean'
           }
         },
-        'required': ['name', 'smtp_password']
+        'required': ['name']
       },
       {
         'description': 'Delete a domain from your account.',

--- a/test/data/fixture.json
+++ b/test/data/fixture.json
@@ -35,8 +35,7 @@
     "description": "Mailgun developers list"
   },
   "new_domain": {
-    "name": "mgjsunits1234.mailgun.org",
-    "smtp_password": "testpassword1"
+    "name": "mgjsunits1234.mailgun.org"
   },
   "existing_domain": {
     "name": "sandbox77047.mailgun.org"

--- a/test/domains.test.js
+++ b/test/domains.test.js
@@ -20,16 +20,6 @@ describe('Domains', () => {
     })
   })
 
-  it('test domains().create() invalid missing smtp password', (done) => {
-    mailgun.domains().create({
-      'name': fixture.new_domain.name
-    }, (err) => {
-      assert.ok(err)
-      assert(/Missing parameter 'smtp_password'/.test(err.message))
-      done()
-    })
-  })
-
   it.skip('test domains().create() ', () => {
     // mailgun.domains().create(fixture.new_domain, function (err, body) {
     //   assert.ifError(err);


### PR DESCRIPTION
From Mailgun api we're getting this error:

`smtp_password cannot be set anymore`

This PR removes that requirement.